### PR TITLE
Add attachment file

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@ python send_mail.py [OPTIONS] CONFIG_PATH
 
 Options:
   --output_path PATH  [default: mails_to_sent]
+  --attachment_file PATH
 ```
 
 * `CONFIG_PATH`: The path to mail config.

--- a/send_mail.py
+++ b/send_mail.py
@@ -40,8 +40,8 @@ def build_mail(
     mail['To'] = receiver_addr
     mail['CC'] = config.get('CC', '')
 
-    if attachment_file is not None:
-        with open(attachment_file, 'rb') as f:
+    if attachment_file:
+        with open(attachment_file, "rb") as f:
             attach = MIMEApplication(f.read())
         attach.add_header('Content-Disposition', 'attachment', filename=str(os.path.basename(attachment_file)))
         mail.attach(attach)

--- a/send_mail.py
+++ b/send_mail.py
@@ -27,7 +27,12 @@ def load_mails(input_dir) -> Dict[str, str]:
     return addr_to_content
 
 
-def build_mail(receiver_addr: str, mail_content: str, config: Dict[str, str], attachment_file=None) -> MIMEText:
+def build_mail(
+    receiver_addr: str,
+    mail_content: str,
+    config: Dict[str, str],
+    attachment_file: str = None,
+) -> MIMEMultipart:
     mail = MIMEMultipart()
     mail.attach(MIMEText(mail_content))
     mail['Subject'] = config.get('Subject', '')

--- a/send_mail.py
+++ b/send_mail.py
@@ -3,7 +3,6 @@ import json
 import logging
 import os
 import smtplib
-import json
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -35,15 +34,19 @@ def build_mail(
 ) -> MIMEMultipart:
     mail = MIMEMultipart()
     mail.attach(MIMEText(mail_content))
-    mail['Subject'] = config.get('Subject', '')
-    mail['From'] = config.get('From', '')
-    mail['To'] = receiver_addr
-    mail['CC'] = config.get('CC', '')
+    mail["Subject"] = config.get("Subject", "")
+    mail["From"] = config.get("From", "")
+    mail["To"] = receiver_addr
+    mail["CC"] = config.get("CC", "")
 
     if attachment_file:
         with open(attachment_file, "rb") as f:
             attach = MIMEApplication(f.read())
-        attach.add_header('Content-Disposition', 'attachment', filename=str(os.path.basename(attachment_file)))
+        attach.add_header(
+            "Content-Disposition",
+            "attachment",
+            filename=str(os.path.basename(attachment_file)),
+        )
         mail.attach(attach)
 
     return mail
@@ -62,14 +65,24 @@ def send_mail(mail, user, password, server_config=None):
 
 
 @click.command()
-@click.argument('config_path', type=click.Path(exists=True))
-@click.option('--mails_path', type=click.Path(exists=False), default='mails_to_sent', show_default=True)
-@click.option('--attachment_file', type=click.Path(exists=False))
+@click.argument("config_path", type=click.Path(exists=True))
+@click.option(
+    "--mails_path",
+    type=click.Path(exists=False),
+    default="mails_to_sent",
+    show_default=True,
+)
+@click.option("--attachment_file", type=click.Path(exists=False))
 def main(mails_path, config_path, attachment_file=None):
-    if click.confirm(f'You are about to send the mails under "{mails_path}". Do you want to continue?', abort=True):
-        user = click.prompt('Please enter your mail account', type=str)
-        password = click.prompt('Please enter you mail password', type=str, hide_input=True)
-        with open(config_path, 'r') as config_file:
+    if click.confirm(
+        f'You are about to send the mails under "{mails_path}". Do you want to continue?',
+        abort=True,
+    ):
+        user = click.prompt("Please enter your mail account", type=str)
+        password = click.prompt(
+            "Please enter you mail password", type=str, hide_input=True
+        )
+        with open(config_path, "r") as config_file:
             config = json.load(config_file)
 
         addr_to_content = load_mails(mails_path)

--- a/send_mail.py
+++ b/send_mail.py
@@ -38,7 +38,7 @@ def build_mail(receiver_addr: str, mail_content: str, config: Dict[str, str], at
     if attachment_file is not None:
         with open(attachment_file, 'rb') as f:
             attach = MIMEApplication(f.read())
-        attach.add_header('Content-Disposition', 'attachment', filename=str(attachment_file))
+        attach.add_header('Content-Disposition', 'attachment', filename=str(os.path.basename(attachment_file)))
         mail.attach(attach)
 
     return mail


### PR DESCRIPTION
Let we can add attachment file when build mail.
# Steps to Test This PR
The following steps are also performed and verified.

## Send The Rendered Emails with Attachment File
```
$python3 send_mail.py example/mail_config.json --attachment_file ~/Desktop/社群軌主題及場地.pdf
You are about to send the mails under "mails_to_sent". Do you want to continue? [y/N]: y      
Please enter your mail account: set840526@gmail.com
Please enter you mail password:
INFO:root:Email sent to example@gmail.com!
```

## Expected Result
The receivers could get the email with attachment file, and the file could open/download correctly.
