### PR TITLE
(bugfix) encoding(utf-8)

### DIFF
--- a/mail_handler/render_mail.py
+++ b/mail_handler/render_mail.py
@@ -57,7 +57,7 @@ def main(template_path, receiver_data, separator, output_path):
         logging.info('Create directory "%s"', output_path)
         Path(output_path).mkdir(parents=True)
 
-    with open(receiver_data, "r") as input_file:
+    with open(receiver_data, "r", encoding="utf-8") as input_file:
         data = json.load(input_file)
         common_data = data["common_data"]
         unique_data = data["unique_data"]

--- a/mail_handler/send_mail.py
+++ b/mail_handler/send_mail.py
@@ -107,7 +107,7 @@ def main(mails_path, config_path, debug, separator, attachment_file=None):
         password = click.prompt(
             "Please enter you mail password", type=str, hide_input=True
         )
-        with open(config_path, "r") as config_file:
+        with open(config_path, "r", encoding="utf-8") as config_file:
             config = json.load(config_file)
 
         address_suffix_to_content = load_mails(mails_path)


### PR DESCRIPTION

## Types of changes

* [X] **Bugfix**

## Description
In windows powershell terminal, run the `render_mail` and `send_mail` command would have error.[1]
And thus, I fix the open json default encoding to utf-8.

[1]
```
Traceback (most recent call last):
  File "c:\python39\lib\runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "c:\python39\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Python39\Scripts\render_mail.exe\__main__.py", line 7, in <module>
  File "c:\python39\lib\site-packages\click\core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "c:\python39\lib\site-packages\click\core.py", line 782, in main
    rv = self.invoke(ctx)
  File "c:\python39\lib\site-packages\click\core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "c:\python39\lib\site-packages\click\core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "c:\python39\lib\site-packages\mail_handler\render_mail.py", line 61, in main
    data = json.load(input_file)
  File "c:\python39\lib\json\__init__.py", line 293, in load
    return loads(fp.read(),
UnicodeDecodeError: 'cp950' codec can't decode byte 0xe5 in position 49: illegal multibyte sequence
```

## Checklist:
- [ ] Add test cases to all the changes you introduce
- [ ] Run `inv lint` locally to ensure all linter checks pass
- [ ] Run `inv test` locally to ensure all test cases pass
- [ ] Run `inv secure` locally to ensure no major vulnerability is introduced
- [ ] Update the documentation if necessary


