### PR TITLE
ci(github-actions): use commitizen-action to replace old hand crafted version bump

### DIFF
--- a/.github/workflows/master-updated.yaml
+++ b/.github/workflows/master-updated.yaml
@@ -9,31 +9,17 @@ jobs:
   bump-version:
     if: "!startsWith(github.event.head_commit.message, 'bump:')"
     runs-on: ubuntu-latest
-
+    name: "Bump version and create changelog with commitizen"
     steps:
       - name: Check out
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+          token: '${{ secrets.PERSONAL_ACCESS_TOKEN }}'
+      - name: Create bump and changelog
+        uses: commitizen-tools/commitizen-action@master
         with:
-          python-version: 3.7
-
-      - name: Install dependencies
-        run: |
-          python -m pip install poetry invoke
-          inv env.init-dev -w
-
-      # do not failed when there is not versioning needed (e.g., document change)
-      - name: Create bump
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          inv git.bump -w
-          git push origin master --tags -v
+          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
   publish-github-page:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Types of changes
* **Other (please describe)**: CI

## Description
Use https://github.com/commitizen-tools/commitizen-action to replace old hand crafted version bump

## Checklist:
- [ ] Add test cases to all the changes you introduce
- [x] Run `inv style` locally to ensure all linter checks pass
- [x] Run `inv test` locally to ensure all test cases pass
- [x] Run `inv secure` locally to ensure no major vulnerability is introduced
- [x] Update the documentation if necessary

## Steps to Test This Pull Request
Create a Pull request and wait for it to be merged

## Expected behavior
The version should be bump according to conventional commit

## Related Issue
<!--If applicable, reference to the issue related to this pull request.-->

## Additional context
<!--Add any other context or screenshots about the pull request here.-->
