### PR TITLE
ci(github-actions): add missing @main for setup-python step

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "git@github.com:Lee-W/cookiecutter-python-template.git",
-  "commit": "70dbb7ed64e78d2c7eba234046252528c5921489",
+  "commit": "de3aaf4ec023a27696ee1de45838d53c72a16da6",
   "context": {
     "cookiecutter": {
       "project_name": "mail handler",

--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Python
-        uses: actions/setup-python
+        uses: actions/setup-python@main
         with:
           python-version: 3.7
 


### PR DESCRIPTION
## Types of changes
- **Other (please describe)** GitHub Actions

## Description
this fix is updated from https://github.com/Lee-W/cookiecutter-python-template

## Checklist:
- [ ] Add test cases to all the changes you introduce
- [x] Run `inv style` locally to ensure all linter checks pass
- [x] Run `inv test` locally to ensure all test cases pass
- [x] Run `inv secure` locally to ensure no major vulnerability is introduced
- [ ] Update the documentation if necessary

## Steps to Test This Pull Request
check python-publish workflow after this one merged back to main

## Expected behavior
publish package to PyPI

## Related Issue
<!--If applicable, reference to the issue related to this pull request.-->

## Additional context
<!--Add any other context or screenshots about the pull request here.-->
